### PR TITLE
Task 563 (Import language translations for objects)

### DIFF
--- a/bin/import_objects_translations.php
+++ b/bin/import_objects_translations.php
@@ -34,14 +34,24 @@ include $cronPath.'init.php';
 \CB\Config::setFlag('disableActivityLog', true);
 
 
-// TESTING
-$trans = [
-	"bn"=> "পুরুষ ",
-	"my"=> "အမျိုးသား "]; //male
-$id = 1467;
+/**
+ * reads the speficied csv file handle
+ * and imports translations for each row into the DB
+ * for the object specified at that row
+ * the csv file should have column header as the first line,
+ * the first column should be for the object id and the remaining
+ * columns for the languages to translate, each language should
+ * be specifed by its language code in the header
+ * @param handle $file
+ */
+function importTranslationsFromFile ($file) {
+	$langs = parseHeader($file);
+	while (!feof($file)) {
+		$row = parseNextTranslations($file, $langs);
+		updateObjectTranslations($row['id'], $row['translations']);
+	}
+}
 
-echo "translating\n";
-updateObjectTranslations($id, $trans);
 
 /**
  * updates language translations of the object
@@ -59,4 +69,50 @@ function updateObjectTranslations ($id, $translations) {
 		$data['data']['title_'.$lg] = $text;
 	}
 	$obj->update($data);
+}
+
+/**
+ * reads the next line of the specified csv
+ * file handle in an attempt to get the languages
+ * in the translation, this should be used to
+ * read the first line of the file, before other
+ * reads are done
+ * @param handle $file
+ * @return array array of language codes from the csv
+ * header row
+ */
+function parseHeader ($file) {
+	$header = fgetcsv($file);
+	$langs = array_slice($header, 1);
+	return $langs
+}
+
+/**
+ * reads the next line of the specified csv file
+ * handle and maps languages to translations of
+ * the object at that row
+ * the first column of the row is considered the object
+ * id and the remaining columns as translations
+ * the number of columns should therefore be 1 + the
+ * size of the $langs array
+ * @param handle $file
+ * @param array $langs array of language codes
+ * @return array associative array with keys id and
+ * translations, where translations is an associative
+ * array mapping languages to translations for the given object id
+ */
+function parseNextTranslations ($file, $langs) {
+	$row = fgetcsv($file);
+	$id = $row[0];
+	// clean id if it starts with # character
+	if($id[0] == '#') {
+		$id = substr($id, 1);
+	}
+	$id = (int) $id;
+	$values = array_slice($row, 1);
+	$trans = array_combine($langs, $values);
+	return [
+		"id" => $id,
+		"translations" => $trans
+	];
 }

--- a/bin/import_objects_translations.php
+++ b/bin/import_objects_translations.php
@@ -1,0 +1,62 @@
+#!/usr/bin/php
+<?php
+/*
+	Import translations for objects from CSV file
+
+	The first column of the CSV file should be the object id,
+	followed by a column for each language, each language
+	should be specified by its 2-character ISO code.
+	So each row contains translations for one object.
+
+	Command parameters:
+	-c : core
+	-f : filename
+
+	Example usage:
+
+	php import_objects_translations -c mycore -f filename.csv
+*/
+
+namespace CB;
+
+ini_set('max_execution_time', 0);
+
+$cronPath = realpath(
+    dirname(__FILE__) . DIRECTORY_SEPARATOR .
+    '..' . DIRECTORY_SEPARATOR .
+    'sys' . DIRECTORY_SEPARATOR .
+    'crons' . DIRECTORY_SEPARATOR
+) . DIRECTORY_SEPARATOR;
+
+$cron_id = 'dummy';
+include $cronPath.'init.php';
+
+\CB\Config::setFlag('disableActivityLog', true);
+
+
+// TESTING
+$trans = [
+	"bn"=> "পুরুষ ",
+	"my"=> "အမျိုးသား "]; //male
+$id = 1467;
+
+echo "translating\n";
+updateObjectTranslations($id, $trans);
+
+/**
+ * updates language translations of the object
+ * with the specified id
+ * @param number $id
+ * @param array $translations associative array mapping
+ * language codes and the corresponding text translations
+ * for this object, e.g. ["en"=>"Cheeze","fr"=>"Fromage"]
+ */
+function updateObjectTranslations ($id, $translations) {
+	$obj = Objects::getCustomClassByObjectId($id);
+	$obj->load();
+	$data = $obj->getData();
+	foreach($translations as $lg=>$text) {
+		$data['data']['title_'.$lg] = $text;
+	}
+	$obj->update($data);
+}


### PR DESCRIPTION
This adds a script in the `bin` directory to import translations for arbitrary objects in a casebox instance from a csv file:

```sh
php import_objects_translations.php -c mycore -f translations.csv
```
Where the `language_import.php` scripts imports new language translations for the general casebox UI, this script imports translations for objects in the tree of the casebox instance.

The CSV file should have a row for each object to be translated, the first column should be the object ID followed by a column for each language, for example:

```csv
ID,en,fr
1,Cheese,Fromage
2,Yes,Oui
```

After running the script you should reindex the solr core.

The script assumes you that you have already configured the languages in your casebox instance (the `config` table) and that you have created `title_$lg` fields for each language in the templates to which the objects belong.