### PR TITLE
Allow option to not skipping security when loading objects for field

### DIFF
--- a/httpsdocs/classes/CB/Browser.php
+++ b/httpsdocs/classes/CB/Browser.php
@@ -610,9 +610,12 @@ class Browser
 
         $search = new Search();
 
-        // temporary: Don't use permissions for Objects fields
-        // it can be later reinforced per field in config
-        $p['skipSecurity'] = true;
+        
+        if (!isset($p['skipSecurity'])) {
+            // temporary: Don't use permissions for Objects fields
+            // it can be later reinforced per field in config
+            $p['skipSecurity'] = true;
+        }
         $rez = $search->query($p);
 
         $this->setCustomIcons($rez['data']);


### PR DESCRIPTION
The method `CB\Browser.getFieldsForObject` sets the `skipSecurity` parameter to true before running the search query to skip security checks when loading objects for field. Since it sets it unconditionally, it would override whatever value the user has set in the field config.

I've added a condition to not set the parameter to true if the parameter is already explicitly set in the config. That way the `skipSecurity` parameter can be turned off (either in the field config or custom source) to load only objects the user has permission to access.

This addresses Task #666, where we need an objects search field to allow users to only select objects they have access to.